### PR TITLE
fix: connect signal that chackes finish every new maze created

### DIFF
--- a/scripts/apps/minigames/maze/maze.gd
+++ b/scripts/apps/minigames/maze/maze.gd
@@ -32,7 +32,6 @@ var heigth_index
 ## Called when the node enters the scene tree for the first time.
 func _ready() -> void:
 	minigame_timer.timer_finished.connect(_on_time_finished)
-	maze_player.position_changed.connect(_check_finish)
 	heigth_index = 5
 	setup()
 
@@ -41,6 +40,8 @@ func setup() -> void:
 	reset_minigame()
 
 func reset_minigame() -> void:
+	maze_player.position_changed.connect(_check_finish)
+	
 	tilemap.clear()
 	define_maze_difficult()
 	generate_maze_size()


### PR DESCRIPTION
## What?
> Fixed the signal connection that checks whether the player has reached the end of the minigame.

## Why?
> When the player reached the final position in the maze, it didn't end.