### PR TITLE
fix: disconnecting next day button after trade

### DIFF
--- a/scripts/utils/day_over_ui.gd
+++ b/scripts/utils/day_over_ui.gd
@@ -29,6 +29,9 @@ func show_day_over() -> void:
 
 	reputation_points_label.text = "%d/%d" % [GameData.daily_reputation_points, MIN_RP_DAY[GameData.current_day]]
 
+	for connection in next_day_button.pressed.get_connections():
+		next_day_button.pressed.disconnect(connection["callable"])
+
 	if GameData.daily_reputation_points >= MIN_RP_DAY[GameData.current_day]:
 		result_rich_text.text = "APROVADO"
 		result_rich_text.add_theme_color_override("default_color", Color("#44cfb2"))


### PR DESCRIPTION
## What?
Adds a feature that disables the “Skip Day” button in case the player fails and restarts the day.

## Why?
The game went on even though the player failed.
