### PR TITLE
Update Godot Engine badge to version 4.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 <div align="center">
   
-  [![Godot Engine](https://img.shields.io/badge/Godot%204.4--stable-%23FFFFFF.svg?logo=godot-engine)](#)
+  [![Godot Engine](https://img.shields.io/badge/Godot%204.6--stable-%23FFFFFF.svg?logo=godot-engine)](#)
   [![GitHub last commit](https://img.shields.io/github/last-commit/dino460/ProjectENIGMA)](#)
 </div>
 


### PR DESCRIPTION
## What?
This pull request updates the Godot Engine version badge in the `README.md` file to reflect support for Godot 4.6-stable instead of 4.4-stable.