### PR TITLE
Add mod loader system and multiple mods with UI improvements

### DIFF
--- a/mods/README.md
+++ b/mods/README.md
@@ -1,0 +1,180 @@
+# Project ENIGMA — Sistema de Mods
+
+Este diretório contém o **mod loader** do Project ENIGMA e os mods que viajam junto com o repositório (built-in).
+
+O sistema é inspirado em Minecraft Forge: o jogo base permanece quase intacto, e mods são pacotes externos que injetam conteúdo e código no boot.
+
+## Como usar (para jogadores)
+
+1. Abre o jogo
+2. No menu principal, clica em **MODS**
+3. Marca os mods que quer ativar
+4. Clica em **Salvar**
+5. **Reinicia o jogo** — mudanças só são aplicadas no próximo boot
+
+Mods built-in (que vêm com a branch `/mods`) ficam em `res://mods/available/`.
+Mods de terceiros ficam em `user://mods/`, que no Linux é:
+```
+~/.local/share/godot/app_userdata/Project ENIGMA/mods/
+```
+
+## Como criar um mod
+
+### Estrutura mínima
+
+```
+meu_mod/
+├── mod.json        # manifesto (obrigatório)
+├── data/           # JSON drop-in (opcional)
+├── assets/         # imagens, sons (opcional)
+└── main.gd         # script com hooks (opcional)
+```
+
+### `mod.json` — manifesto
+
+```json
+{
+  "id": "seunome.nome_do_mod",
+  "name": "Nome Visível",
+  "version": "0.1.0",
+  "authors": ["Seu Nome"],
+  "description": "Explicação do que o mod faz.",
+  "priority": 100,
+  "depends": [],
+  "data": {
+    "messages_dir": "data/messages",
+    "news": { "path": "data/news.json", "mode": "merge" }
+  },
+  "main_script": "main.gd"
+}
+```
+
+Campos:
+
+| Campo | Tipo | Obrigatório | Descrição |
+|---|---|---|---|
+| `id` | string | sim | Identificador único. Use namespace (`autor.nome`). |
+| `name` | string | não | Nome exibido na UI. Default: `id`. |
+| `version` | string | não | Semver. Default: `0.0.0`. |
+| `authors` | array | não | Lista de autores. |
+| `description` | string | não | Texto mostrado na tela MODS. |
+| `priority` | int | não | Maior carrega primeiro. Default: `0`. |
+| `depends` | array | não | IDs de outros mods exigidos pra carregar. |
+| `data` | object | não | Sobreposição de dados JSON do jogo. Ver abaixo. |
+| `main_script` | string | não | Path relativo de um `.gd` com hooks. |
+| `assets` | string | não | Path relativo da pasta de assets. |
+| `pack` | string | não | Path relativo de um `.pck` que sobrescreve scripts do jogo. |
+
+### Data targets disponíveis
+
+Cada chave em `"data"` aponta para um lugar específico do jogo:
+
+| Chave | Tipo | Caminho no jogo |
+|---|---|---|
+| `messages_dir` | diretório | `res://data/messages` |
+| `emails_dir` | diretório | `res://data/emails` |
+| `tasks_dir` | diretório | `res://data/random/tasks` |
+| `scams_dir` | diretório | `res://data/random/scams` |
+| `events` | arquivo | `res://data/events/events.json` |
+| `news` | arquivo | `res://data/news.json` |
+| `shops_items` | arquivo | `res://data/browser/shops_items.json` |
+| `pix_codes` | arquivo | `res://data/bank/pix_codes_data.json` |
+| `ticket_codes` | arquivo | `res://data/bank/ticket_codes_data.json` |
+| `reviews` | arquivo | `res://data/browser/reviewed_companies.json` |
+
+**Diretórios** são aditivos: os JSONs do seu mod são lidos junto com os do jogo base, ordenados alfabeticamente.
+
+**Arquivos** suportam dois modos:
+- `"mode": "merge"` (default) — deep merge: dicionários combinam por chave, arrays concatenam, escalares são sobrescritos
+- `"mode": "replace"` — substitui o conteúdo inteiro
+
+### `main.gd` — hooks GDScript
+
+```gdscript
+extends Node
+
+var api: ModLoaderAPI
+
+func _on_mod_load(mod_api: ModLoaderAPI) -> void:
+    api = mod_api
+    api.info("inicializado")
+    api.hook("post_data_load", _on_data_loaded)
+    api.hook("apps_data_loaded", _on_apps_loaded)
+
+func _on_data_loaded(roots: Dictionary) -> void:
+    # roots contém: messages, emails, tasks, scams, reviews,
+    # shops, pix, tickets, events — todos já com overlays aplicados
+    api.info("dados carregados: %d threads de mensagens" % roots.messages.size())
+
+func _on_apps_loaded(apps_data: Dictionary) -> void:
+    # apps_data é o dicionário GameData.apps_data
+    # Você pode mutar in-place (mudar ícones, descrições, etc)
+    pass
+```
+
+A API (`ModLoaderAPI`) expõe:
+
+| Método | Descrição |
+|---|---|
+| `hook(name, callable)` | Registra callback pra um evento. |
+| `info(msg)` / `warn(msg)` | Logging com prefixo do mod. |
+| `mod_path()` | Retorna o caminho absoluto do mod. |
+| `resolve_asset(rel_path)` | Resolve `mod://seu_id/foo.png` pra path real. |
+
+Hooks disponíveis no v1:
+
+| Hook | Args | Quando |
+|---|---|---|
+| `post_data_load` | `(roots: Dictionary)` | Depois dos JSONs serem carregados, antes dos directors consumirem |
+| `apps_data_loaded` | `(apps_data: Dictionary)` | Depois do `GameData._ready` registrar os apps |
+
+### Assets
+
+Coloca arquivos em `assets/` e referencia via URI `mod://`:
+
+```gdscript
+var icon_path = api.resolve_asset("icons/meu_icone.png")
+var texture = load(icon_path)
+```
+
+### Substituindo scripts inteiros (avançado)
+
+Pra mods que precisam reescrever lógica do jogo (estilo Forge bytecode injection), use o campo `"pack"` no manifesto apontando pra um `.pck`:
+
+```json
+{
+  "id": "seu.mod",
+  "pack": "patches.pck"
+}
+```
+
+O loader chama `ProjectSettings.load_resource_pack(path, replace_files=true)` — arquivos do `.pck` substituem os do jogo base com mesmo path.
+
+Como buildar o `.pck`: usar o Godot editor com um projeto separado que tem só os arquivos modificados na mesma estrutura `res://`. Ferramenta: **Project > Export > Add... > Export PCK/ZIP**.
+
+## Segurança
+
+Mods em `user://mods/` que incluem `main_script` têm **acesso total às APIs do GDScript**: podem ler/escrever arquivos, chamar `OS.execute`, fazer requisições de rede etc. Trate-os como qualquer plugin de terceiros — instala só de fontes confiáveis.
+
+O loader emite um warning no console quando carrega script de mod do `user://`.
+
+## Layout do diretório `mods/`
+
+```
+mods/
+├── README.md                       # este arquivo
+├── loader/                         # implementação do loader
+│   ├── mod_descriptor.gd           # parser do mod.json
+│   ├── mod_loader_api.gd           # fachada que mods recebem
+│   └── ui/
+│       ├── mods_screen.tscn        # tela MODS do menu principal
+│       ├── mods_screen.gd
+│       └── mods_button_handler.gd  # handler do botão MODS
+└── available/                      # mods built-in
+    └── exemplo_basico/
+        ├── mod.json
+        ├── main.gd
+        └── data/messages/modsbot_branches.json
+```
+
+A lógica central (`ModLoader` autoload) está em [scripts/singletons/mod_loader.gd](../scripts/singletons/mod_loader.gd).

--- a/mods/available/calculo_2_pagamentos/main.gd
+++ b/mods/available/calculo_2_pagamentos/main.gd
@@ -1,0 +1,124 @@
+extends Node
+
+var api: ModLoaderAPI
+
+
+func _on_mod_load(mod_api: ModLoaderAPI) -> void:
+	api = mod_api
+	api.info("ativo — valores em R$ serão substituídos por expressões matemáticas extremas")
+	api.hook("post_data_load", _on_data_loaded)
+
+
+func _on_data_loaded(roots: Dictionary) -> void:
+	var rewritten := 0
+	var message_roots: Array = roots.get("messages", [])
+	for thread in message_roots:
+		if typeof(thread) != TYPE_DICTIONARY:
+			continue
+		var branches: Dictionary = thread.get("branches", {})
+		for branch_name in branches.keys():
+			for msg in branches[branch_name]:
+				if typeof(msg) != TYPE_DICTIONARY:
+					continue
+				if _rewrite_message_object(msg):
+					rewritten += 1
+	api.info("aplicado em %d mensagens" % rewritten)
+
+
+func _rewrite_message_object(msg: Dictionary) -> bool:
+	var changed := false
+	if msg.has("text") and typeof(msg["text"]) == TYPE_STRING:
+		var new_text := _substitute_money(msg["text"])
+		if new_text != msg["text"]:
+			msg["text"] = new_text
+			changed = true
+	if msg.has("choices") and typeof(msg["choices"]) == TYPE_ARRAY:
+		for choice in msg["choices"]:
+			if typeof(choice) != TYPE_DICTIONARY:
+				continue
+			if choice.has("player_text") and typeof(choice["player_text"]) == TYPE_STRING:
+				var new_choice := _substitute_money(choice["player_text"])
+				if new_choice != choice["player_text"]:
+					choice["player_text"] = new_choice
+					changed = true
+	return changed
+
+
+# Matches "R$ 58", "R$ 58,90", "R$ 5.000", "R$ 5.000,00", "R$58,90", etc.
+func _substitute_money(text: String) -> String:
+	var rx := RegEx.new()
+	rx.compile("R\\$\\s*([\\d.]+)(,(\\d+))?")
+	var matches := rx.search_all(text)
+	if matches.is_empty():
+		return text
+
+	var result := text
+	# Process in reverse so earlier indices remain valid after each substitution
+	matches.reverse()
+	for m in matches:
+		var int_str: String = m.get_string(1)
+		var int_part: int = int(int_str.replace(".", ""))
+		var dec_part: String = m.get_string(3)
+
+		var expr: String
+		if dec_part != "":
+			expr = "R$ %s,%s" % [_express_int(int_part), dec_part]
+		else:
+			expr = "R$ %s" % _express_int(int_part)
+
+		result = result.substr(0, m.get_start()) + expr + result.substr(m.get_end())
+	return result
+
+
+# Returns an expression equivalent to n, but n itself NEVER appears
+# literally in the rendered string. The player has to actually compute
+# something to find out the value. Salt values are derived deterministically
+# from n via hash-style arithmetic, so the same amount always renders the
+# same way across reloads.
+func _express_int(n: int) -> String:
+	if n == 0:
+		return "(cos(π/2) · 47)"
+
+	var seed_val: int = abs(n)
+	var idx: int = seed_val % 6
+
+	var salt_a: int = ((seed_val * 31) % 947) + 137
+	var salt_b: int = ((seed_val * 67) % 1117) + 211
+
+	match idx:
+		0:
+			# (a + b) where a + b = n
+			# Switch to subtractive form when salt_a >= n to avoid a negative term
+			if salt_a >= n:
+				return "(%d − %d)" % [salt_a, salt_a - n]
+			return "(%d + %d)" % [salt_a, n - salt_a]
+		1:
+			# (a − b) where a − b = n, a = n + b
+			return "(%d − %d)" % [n + salt_b, salt_b]
+		2:
+			# (∫_a^b dx) where b − a = n
+			return "(∫_%d^%d dx)" % [salt_a, salt_a + n]
+		3:
+			# (Σᵢ₌ₐ^b 1) where b − a + 1 = n
+			return "(Σᵢ₌%d^%d 1)" % [salt_a, salt_a + n - 1]
+		4:
+			# ((a · b) − c) where a·b − c = n.
+			# a, b scaled to roughly sqrt(n) so the multiplication is non-trivial
+			# regardless of how big n is.
+			var sqrt_n: int = int(sqrt(float(max(1, n))))
+			var base: int = sqrt_n + 17
+			var a: int = base + (seed_val % 31) + 3
+			var b: int = base + ((seed_val * 7) % 37) + 5
+			var c: int = a * b - n
+			return "((%d · %d) − %d)" % [a, b, c]
+		5:
+			# ((a + b) − c) where a + b − c = n.
+			# Need a + b > n so c stays positive; scale up if salt sum is too small.
+			var a5: int = salt_a
+			var b5: int = salt_b
+			if a5 + b5 <= n:
+				var scale: int = (n / (a5 + b5)) + 2
+				a5 *= scale
+				b5 *= scale
+			return "((%d + %d) − %d)" % [a5, b5, a5 + b5 - n]
+	return str(n)

--- a/mods/available/calculo_2_pagamentos/main.gd.uid
+++ b/mods/available/calculo_2_pagamentos/main.gd.uid
@@ -1,0 +1,1 @@
+uid://d2fed4sr1xg3t

--- a/mods/available/calculo_2_pagamentos/mod.json
+++ b/mods/available/calculo_2_pagamentos/mod.json
@@ -1,0 +1,10 @@
+{
+	"id": "felipetto.calculo_2_pagamentos",
+	"name": "Cálculo II™ — Pagamentos",
+	"version": "0.1.0",
+	"authors": ["Guilherme Felipetto"],
+	"description": "Substitui TODOS os valores monetários (R$ X,XX) que aparecem em mensagens de NPCs por expressões matemáticas equivalentes ONDE O NÚMERO ORIGINAL NÃO APARECE LITERALMENTE EM LUGAR NENHUM. O jogador TEM QUE calcular pra saber quanto vai pagar.\n\nUsa números 'salgados' deterministicamente derivados via hash do valor: somas, diferenças, produtos descompostos, integrais ∫_a^b dx (onde b−a = valor), somatórios. A parte dos centavos é preservada (escrever decimais em integrais seria crueldade desnecessária).\n\nExemplo: 'pague R$ 100,00' não vira '(100+π−π),00' (óbvio) — vira algo como '(∫_413^513 dx),00' (calcule 513−413 pra descobrir).\n\nFunciona junto com long_payment_codes (operam em capturas regex disjuntas).",
+	"priority": 25,
+	"depends": [],
+	"main_script": "main.gd"
+}

--- a/mods/available/exemplo_basico/data/messages/modsbot_branches.json
+++ b/mods/available/exemplo_basico/data/messages/modsbot_branches.json
@@ -1,0 +1,27 @@
+{
+	"thread_id": "modsbot",
+	"sender": "ModsBot",
+	"entry_points": [
+		{
+			"day": 0,
+			"branch": "d0_intro",
+			"relative_due_time": 5
+		}
+	],
+	"branches": {
+		"d0_intro": [
+			{
+				"id": "modsbot_0_0",
+				"text": "Olá! Eu sou o ModsBot — esta mensagem foi injetada pelo mod 'Exemplo Básico'."
+			},
+			{
+				"id": "modsbot_0_1",
+				"text": "Se você está vendo isto, o sistema de mods está funcionando corretamente. ✓"
+			},
+			{
+				"id": "modsbot_0_2",
+				"text": "Você pode desativar este mod em MENU PRINCIPAL > MODS."
+			}
+		]
+	}
+}

--- a/mods/available/exemplo_basico/main.gd
+++ b/mods/available/exemplo_basico/main.gd
@@ -1,0 +1,13 @@
+extends Node
+
+var api: ModLoaderAPI
+
+
+func _on_mod_load(mod_api: ModLoaderAPI) -> void:
+	api = mod_api
+	api.info("script carregado")
+	api.hook("apps_data_loaded", _on_apps_data_loaded)
+
+
+func _on_apps_data_loaded(apps_data: Dictionary) -> void:
+	api.info("apps_data carregado, %d apps registrados" % apps_data.size())

--- a/mods/available/exemplo_basico/main.gd.uid
+++ b/mods/available/exemplo_basico/main.gd.uid
@@ -1,0 +1,1 @@
+uid://gaiuc7eo4b4s

--- a/mods/available/exemplo_basico/mod.json
+++ b/mods/available/exemplo_basico/mod.json
@@ -1,0 +1,13 @@
+{
+	"id": "felipetto.exemplo_basico",
+	"name": "Exemplo Básico",
+	"version": "0.1.0",
+	"authors": ["Guilherme Felipetto"],
+	"description": "Mod de exemplo que mostra as 3 capacidades do loader: (1) adiciona uma thread de mensagens nova com um NPC chamado ModsBot, (2) declara metadata no manifesto, (3) registra um hook GDScript que loga quando o jogo carrega dados.",
+	"priority": 100,
+	"depends": [],
+	"data": {
+		"messages_dir": "data/messages"
+	},
+	"main_script": "main.gd"
+}

--- a/mods/available/long_payment_codes/main.gd
+++ b/mods/available/long_payment_codes/main.gd
@@ -1,0 +1,124 @@
+extends Node
+
+const TARGET_LENGTH := 30
+const CHARSET := "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+
+var api: ModLoaderAPI
+var _code_remap: Dictionary = {}
+var _word_boundary_cache: Dictionary = {}
+
+
+func _on_mod_load(mod_api: ModLoaderAPI) -> void:
+	api = mod_api
+	api.info("ativo — códigos de transação serão alongados para %d chars" % TARGET_LENGTH)
+	api.hook("post_data_load", _on_data_loaded)
+
+
+func _on_data_loaded(roots: Dictionary) -> void:
+	_code_remap.clear()
+	_word_boundary_cache.clear()
+
+	_lengthen_codes_in_dict(roots.get("pix", {}))
+	_lengthen_codes_in_dict(roots.get("tickets", {}))
+
+	var rewritten_threads := _rewrite_messages(roots.get("messages", []))
+
+	api.info("alongados %d códigos; atualizadas referências em %d/%d threads de mensagens" % [
+		_code_remap.size(), rewritten_threads, roots.get("messages", []).size()
+	])
+
+
+func _lengthen_codes_in_dict(dict: Dictionary) -> void:
+	if dict.is_empty():
+		return
+	var originals: Array = dict.keys()
+	for code in originals:
+		var long_code: String = _make_long_code(code)
+		_code_remap[code] = long_code
+		dict[long_code] = dict[code]
+		dict.erase(code)
+
+
+func _make_long_code(original: String) -> String:
+	var result: String = original
+	var seed_val: int = original.hash()
+	if seed_val < 0:
+		seed_val = -seed_val
+	while result.length() < TARGET_LENGTH:
+		seed_val = (seed_val * 1103515245 + 12345) & 0x7FFFFFFF
+		result += CHARSET[seed_val % CHARSET.length()]
+	return result.substr(0, TARGET_LENGTH)
+
+
+func _rewrite_messages(message_roots: Array) -> int:
+	var modified_count := 0
+	for thread in message_roots:
+		if typeof(thread) != TYPE_DICTIONARY:
+			continue
+		var branches: Dictionary = thread.get("branches", {})
+		var touched := false
+		for branch_name in branches.keys():
+			var messages: Array = branches[branch_name]
+			for msg in messages:
+				if typeof(msg) != TYPE_DICTIONARY:
+					continue
+				if _rewrite_message_object(msg):
+					touched = true
+		if touched:
+			modified_count += 1
+	return modified_count
+
+
+func _rewrite_message_object(msg: Dictionary) -> bool:
+	var any_change := false
+
+	if msg.has("text") and typeof(msg["text"]) == TYPE_STRING:
+		var new_text: String = _apply_remap(msg["text"])
+		if new_text != msg["text"]:
+			msg["text"] = new_text
+			any_change = true
+
+	if msg.has("choices") and typeof(msg["choices"]) == TYPE_ARRAY:
+		for choice in msg["choices"]:
+			if typeof(choice) != TYPE_DICTIONARY:
+				continue
+			if choice.has("player_text") and typeof(choice["player_text"]) == TYPE_STRING:
+				var new_choice_text: String = _apply_remap(choice["player_text"])
+				if new_choice_text != choice["player_text"]:
+					choice["player_text"] = new_choice_text
+					any_change = true
+
+	return any_change
+
+
+# Substitutes original codes with long ones using word-boundary RegEx
+# to avoid clobbering codes that happen to appear inside larger words/numbers.
+func _apply_remap(text: String) -> String:
+	var result: String = text
+	for orig_code in _code_remap.keys():
+		if not (orig_code in result):
+			continue
+		var regex: RegEx = _get_boundary_regex(orig_code)
+		result = regex.sub(result, _code_remap[orig_code], true)
+	return result
+
+
+func _get_boundary_regex(code: String) -> RegEx:
+	if _word_boundary_cache.has(code):
+		return _word_boundary_cache[code]
+	var rx := RegEx.new()
+	# \b matches word boundary; works for both alphanumeric PIX and numeric tickets
+	rx.compile("\\b" + _regex_escape(code) + "\\b")
+	_word_boundary_cache[code] = rx
+	return rx
+
+
+func _regex_escape(s: String) -> String:
+	const SPECIAL := ".\\+*?[^]$(){}=!<>|:-/"
+	var out := ""
+	for ch in s:
+		if ch in SPECIAL:
+			out += "\\" + ch
+		else:
+			out += ch
+	return out

--- a/mods/available/long_payment_codes/main.gd
+++ b/mods/available/long_payment_codes/main.gd
@@ -1,6 +1,6 @@
 extends Node
 
-const TARGET_LENGTH := 30
+const TARGET_LENGTH := 120
 const CHARSET := "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
 
 var api: ModLoaderAPI

--- a/mods/available/long_payment_codes/main.gd.uid
+++ b/mods/available/long_payment_codes/main.gd.uid
@@ -1,0 +1,1 @@
+uid://8s1k0e3mjqx3

--- a/mods/available/long_payment_codes/mod.json
+++ b/mods/available/long_payment_codes/mod.json
@@ -3,7 +3,7 @@
 	"name": "Códigos de Transação Gigantescos",
 	"version": "0.1.0",
 	"authors": ["Guilherme Felipetto"],
-	"description": "Transforma todos os códigos estáticos de PIX (5 chars) e boleto (6 chars) em códigos de 30 caracteres absurdamente longos. Atualiza automaticamente todas as referências nas mensagens dos NPCs para apontar para os novos códigos.\n\nAviso: os códigos dinâmicos gerados em compras dentro do jogo continuam com 5/6 caracteres — isso só afeta os códigos cravados no enredo. Para alongar TODOS, seria necessário um mod adicional que substitua o bank_director via pack.pck.",
+	"description": "Transforma todos os códigos estáticos de PIX (5 chars) e boleto (6 chars) em códigos de 60 caracteres absurdamente longos. Atualiza automaticamente todas as referências nas mensagens dos NPCs para apontar para os novos códigos.\n\nAviso: os códigos dinâmicos gerados em compras dentro do jogo continuam com 5/6 caracteres — isso só afeta os códigos cravados no enredo. Para alongar TODOS, seria necessário um mod adicional que substitua o bank_director via pack.pck.",
 	"priority": 50,
 	"depends": [],
 	"main_script": "main.gd"

--- a/mods/available/long_payment_codes/mod.json
+++ b/mods/available/long_payment_codes/mod.json
@@ -1,0 +1,10 @@
+{
+	"id": "felipetto.long_payment_codes",
+	"name": "Códigos de Transação Gigantescos",
+	"version": "0.1.0",
+	"authors": ["Guilherme Felipetto"],
+	"description": "Transforma todos os códigos estáticos de PIX (5 chars) e boleto (6 chars) em códigos de 30 caracteres absurdamente longos. Atualiza automaticamente todas as referências nas mensagens dos NPCs para apontar para os novos códigos.\n\nAviso: os códigos dinâmicos gerados em compras dentro do jogo continuam com 5/6 caracteres — isso só afeta os códigos cravados no enredo. Para alongar TODOS, seria necessário um mod adicional que substitua o bank_director via pack.pck.",
+	"priority": 50,
+	"depends": [],
+	"main_script": "main.gd"
+}

--- a/mods/available/notificacoes_simultaneas/data/messages/agiota_sereno_branches.json
+++ b/mods/available/notificacoes_simultaneas/data/messages/agiota_sereno_branches.json
@@ -1,0 +1,47 @@
+{
+	"thread_id": "agiota_sereno",
+	"sender": "Jorginho 🦈",
+	"entry_points": [
+		{
+			"day": 2,
+			"branch": "d2_lembrete_amigavel",
+			"relative_due_time": 20
+		}
+	],
+	"branches": {
+		"d2_lembrete_amigavel": [
+			{
+				"id": "agi_0_0",
+				"text": "e aí"
+			},
+			{
+				"id": "agi_0_1",
+				"text": "beleza"
+			},
+			{
+				"id": "agi_0_2",
+				"text": "se lembra de mim"
+			},
+			{
+				"id": "agi_0_3",
+				"text": "beleza"
+			},
+			{
+				"id": "agi_0_4",
+				"text": "então"
+			},
+			{
+				"id": "agi_0_5",
+				"text": "beleza"
+			},
+			{
+				"id": "agi_0_6",
+				"text": "voce tem 47 minutos"
+			},
+			{
+				"id": "agi_0_7",
+				"text": "beleza"
+			}
+		]
+	}
+}

--- a/mods/available/notificacoes_simultaneas/data/messages/banco_seguranca_branches.json
+++ b/mods/available/notificacoes_simultaneas/data/messages/banco_seguranca_branches.json
@@ -1,0 +1,43 @@
+{
+	"thread_id": "banco_seguranca",
+	"sender": "BancoBank Segurança",
+	"entry_points": [
+		{
+			"day": 2,
+			"branch": "d2_verificacao_urgente",
+			"relative_due_time": 20
+		}
+	],
+	"branches": {
+		"d2_verificacao_urgente": [
+			{
+				"id": "banco_0_0",
+				"text": "Prezado(a) Cliente, identificamos atividade SUSPEITA em sua conta."
+			},
+			{
+				"id": "banco_0_1",
+				"text": "Para sua segurança, precisamos validar sua identidade IMEDIATAMENTE."
+			},
+			{
+				"id": "banco_0_2",
+				"text": "Por favor, envie uma SELFIE segurando seu documento RG."
+			},
+			{
+				"id": "banco_0_3",
+				"text": "Envie também uma selfie segurando seu CPF."
+			},
+			{
+				"id": "banco_0_4",
+				"text": "E uma selfie segurando seu CARTÃO DE CRÉDITO (frente e verso, com o CVV visível)."
+			},
+			{
+				"id": "banco_0_5",
+				"text": "E sua senha do banco escrita em um papel."
+			},
+			{
+				"id": "banco_0_6",
+				"text": "Isso É um procedimento padrão de segurança e definitivamente não É um golpe. 🏦"
+			}
+		]
+	}
+}

--- a/mods/available/notificacoes_simultaneas/data/messages/mae_aflita_branches.json
+++ b/mods/available/notificacoes_simultaneas/data/messages/mae_aflita_branches.json
@@ -1,0 +1,51 @@
+{
+	"thread_id": "mae_aflita",
+	"sender": "Mãe ❤️",
+	"entry_points": [
+		{
+			"day": 2,
+			"branch": "d2_audio_panic",
+			"relative_due_time": 20
+		}
+	],
+	"branches": {
+		"d2_audio_panic": [
+			{
+				"id": "mae_0_0",
+				"text": "FILHO"
+			},
+			{
+				"id": "mae_0_1",
+				"text": "ME LIGA"
+			},
+			{
+				"id": "mae_0_2",
+				"text": "🎤 [áudio: 2:34]"
+			},
+			{
+				"id": "mae_0_3",
+				"text": "🎤 [áudio: 4:12]"
+			},
+			{
+				"id": "mae_0_4",
+				"text": "🎤 [áudio: 0:03]"
+			},
+			{
+				"id": "mae_0_5",
+				"text": "🎤 [áudio: 8:47]"
+			},
+			{
+				"id": "mae_0_6",
+				"text": "POR QUE VC NAO RESPONDE"
+			},
+			{
+				"id": "mae_0_7",
+				"text": "AHHHHHHHH NAO É NADA. esquece"
+			},
+			{
+				"id": "mae_0_8",
+				"text": "🎤 [áudio: 11:23]"
+			}
+		]
+	}
+}

--- a/mods/available/notificacoes_simultaneas/data/messages/tutorial_sarcastico_branches.json
+++ b/mods/available/notificacoes_simultaneas/data/messages/tutorial_sarcastico_branches.json
@@ -1,0 +1,43 @@
+{
+	"thread_id": "tutorial_sarcastico",
+	"sender": "Tutorial™",
+	"entry_points": [
+		{
+			"day": 2,
+			"branch": "d2_observacoes_construtivas",
+			"relative_due_time": 20
+		}
+	],
+	"branches": {
+		"d2_observacoes_construtivas": [
+			{
+				"id": "tut_0_0",
+				"text": "Olá! Eu sou o Tutorial™."
+			},
+			{
+				"id": "tut_0_1",
+				"text": "Notei que você está recebendo várias mensagens ao mesmo tempo."
+			},
+			{
+				"id": "tut_0_2",
+				"text": "Dica de Cibersegurança Nível 1: quando 4 pessoas te mandam mensagem ao mesmo tempo, provavelmente 3 delas são golpe."
+			},
+			{
+				"id": "tut_0_3",
+				"text": "Dica de Cibersegurança Nível 2: a quarta também."
+			},
+			{
+				"id": "tut_0_4",
+				"text": "Observação: sim, eu também posso ser golpe. Você nunca sabe."
+			},
+			{
+				"id": "tut_0_5",
+				"text": "Aliás, vou te mandar um link pra atualizar o Tutorial™: http://bit.ly/tutorial-real-juro-mesmo"
+			},
+			{
+				"id": "tut_0_6",
+				"text": "(é golpe)"
+			}
+		]
+	}
+}

--- a/mods/available/notificacoes_simultaneas/mod.json
+++ b/mods/available/notificacoes_simultaneas/mod.json
@@ -1,0 +1,12 @@
+{
+	"id": "felipetto.notificacoes_simultaneas",
+	"name": "Notificações Simultâneas do Caos",
+	"version": "0.1.0",
+	"authors": ["Guilherme Felipetto"],
+	"description": "No dia 2 às 8:20 da manhã, você recebe 4 contatos diferentes mandando mensagens ao mesmo tempo: mãe aflita mandando áudio, agiota sereno mandando só 'beleza', banco pedindo selfie urgente, e o tutorial do jogo zoando a sua cara. Cada um manda 4-5 mensagens em sequência rápida. Bom dia.",
+	"priority": 30,
+	"depends": [],
+	"data": {
+		"messages_dir": "data/messages"
+	}
+}

--- a/mods/available/presidente_golpista/data/messages/presidente_branches.json
+++ b/mods/available/presidente_golpista/data/messages/presidente_branches.json
@@ -1,0 +1,119 @@
+{
+	"thread_id": "presidente_brasil",
+	"sender": "PRESIDENTE DO BRASIL OFICIAL ✓",
+	"entry_points": [
+		{
+			"day": 1,
+			"branch": "d1_emergencia_nacional",
+			"relative_due_time": 30
+		}
+	],
+	"branches": {
+		"d1_emergencia_nacional": [
+			{
+				"id": "pres_0_0",
+				"text": "OLA CIDADAO BRASILEIRO 🇧🇷🇧🇷🇧🇷"
+			},
+			{
+				"id": "pres_0_1",
+				"text": "AQUI QUEM FALA E O PRESIDENTE DO BRASIL EM PESSOA"
+			},
+			{
+				"id": "pres_0_2",
+				"text": "ESTOU TE CONTATANDO PESSOALMENTE PORQUE VOCE FOI SELECIONADO 1 ENTRE 213 MILHOES DE BRASILEIROS"
+			},
+			{
+				"id": "pres_0_3",
+				"text": "TEMOS UMA EMERGENCIA NACIONAL DE NIVEL MAXIMO"
+			},
+			{
+				"id": "pres_0_4",
+				"text": "O TESOURO NACIONAL ESTA TEMPORARIAMENTE COM O CARTAO BLOQUEADO E PRECISO DESBLOQUEAR URGENTE PARA PAGAR A LUZ DO PALACIO DO PLANALTO"
+			},
+			{
+				"id": "pres_0_5",
+				"text": "PRECISO QUE VOCE FACA UM PIX DE R$ 5.000 PARA O CODIGO ABAIXO IMEDIATAMENTE"
+			},
+			{
+				"id": "pres_0_6",
+				"text": "VOCE SERA RESSARCIDO EM 7 DIAS UTEIS COM 200% DE JUROS COMO AGRADECIMENTO DA REPUBLICA",
+				"choices": [
+					{
+						"id": "pres_choice_aceitar",
+						"player_text": "É claro, Senhor Presidente! 🫡",
+						"npc_reply": {
+							"goto_branch": "d1_caiu_no_golpe",
+							"delay_ticks": 0
+						}
+					},
+					{
+						"id": "pres_choice_desconfiar",
+						"player_text": "Isso parece golpe...",
+						"npc_reply": {
+							"goto_branch": "d1_nega_o_golpe",
+							"delay_ticks": 0
+						}
+					},
+					{
+						"id": "pres_choice_zoar",
+						"player_text": "🚨🚨🚨 GOLPE DETECTADO 🚨🚨🚨",
+						"npc_reply": {
+							"goto_branch": "d1_revelacao",
+							"delay_ticks": 0
+						}
+					}
+				]
+			}
+		],
+		"d1_caiu_no_golpe": [
+			{
+				"id": "pres_aceitar_0",
+				"text": "OTIMO CIDADAO! VOCE E UM PATRIOTA DE VERDADE 🇧🇷"
+			},
+			{
+				"id": "pres_aceitar_1",
+				"text": "O CODIGO PIX E: PRESIDENT3-OFICI4L-CERT3Z4-N4O-3-GOLPE"
+			},
+			{
+				"id": "pres_aceitar_2",
+				"text": "AGUARDO O COMPROVANTE. A BANDEIRA DO BRASIL AGRADECE 🇧🇷🇧🇷🇧🇷🇧🇷🇧🇷"
+			}
+		],
+		"d1_nega_o_golpe": [
+			{
+				"id": "pres_nega_0",
+				"text": "COMO OUSA DUVIDAR DO PRESIDENTE 😡"
+			},
+			{
+				"id": "pres_nega_1",
+				"text": "VOCE QUER QUE EU LIGUE PRO SEU CHEFE E CONTE QUE VOCE NAO QUIS AJUDAR O PAIS?"
+			},
+			{
+				"id": "pres_nega_2",
+				"text": "VOU REPETIR MAIS UMA VEZ: FACA O PIX AGORA"
+			},
+			{
+				"id": "pres_nega_3",
+				"text": "OBS: ESTA MENSAGEM E TOTALMENTE LEGITIMA E NAO TEM RELACAO COM NENHUM GOLPE DE FALSO PRESIDENTE QUE OS GOLPISTAS APLICAM POR AI 😇"
+			}
+		],
+		"d1_revelacao": [
+			{
+				"id": "pres_revel_0",
+				"text": "...."
+			},
+			{
+				"id": "pres_revel_1",
+				"text": "ok voce me pegou"
+			},
+			{
+				"id": "pres_revel_2",
+				"text": "sou um estagiario de 19 anos de uma favela em Manaus"
+			},
+			{
+				"id": "pres_revel_3",
+				"text": "se voce mandar R$ 50 eu fico de boa 🙏"
+			}
+		]
+	}
+}

--- a/mods/available/presidente_golpista/mod.json
+++ b/mods/available/presidente_golpista/mod.json
@@ -1,0 +1,12 @@
+{
+	"id": "felipetto.presidente_golpista",
+	"name": "Presidente do Brasil te pede PIX",
+	"version": "0.1.0",
+	"authors": ["Guilherme Felipetto"],
+	"description": "Adiciona uma conversa de WhatsApp com o 'PRESIDENTE DO BRASIL EM PESSOA' que precisa urgentemente de um PIX de R$ 5000 pra resolver uma crise nacional. Mensagem chega no dia 1 às 8:30 da manhã. Spoiler: o pix vai pra outro PIX.",
+	"priority": 30,
+	"depends": [],
+	"data": {
+		"messages_dir": "data/messages"
+	}
+}

--- a/mods/available/produtos_absurdos_amazonia/data/browser/shops_items.json
+++ b/mods/available/produtos_absurdos_amazonia/data/browser/shops_items.json
@@ -1,0 +1,28 @@
+{
+	"amazonia": [
+		{"id": 1101, "name": "Casca de Banana Usada (Marca Premium)", "price": 0.01, "logo": "res://assets/icons/shops/products/emilia/brigadeiro_maracuja.png"},
+		{"id": 1102, "name": "AK-47 da Promoção (Sem Procedência)", "price": 49.90, "logo": "res://assets/icons/shops/products/amazonia/aco.png"},
+		{"id": 1103, "name": "Granada Pin Levemente Defeituoso", "price": 12.90, "logo": "res://assets/icons/shops/products/amazonia/furadeira.png"},
+		{"id": 1104, "name": "Cocaína Original do Cartel do Maracujá™", "price": 999999.99, "logo": "res://assets/icons/shops/products/amazonia/n2_liquido.png"},
+		{"id": 1105, "name": "Maconha 100% Orgânica Free-Range Vegana", "price": 420.69, "logo": "res://assets/icons/shops/products/emilia/brigadeiro.png"},
+		{"id": 1106, "name": "Ar Comprimido Engarrafado (Sabor Premium)", "price": 89.00, "logo": "res://assets/icons/shops/products/amazonia/n2_liquido.png"},
+		{"id": 1107, "name": "Rim Humano Pouco Usado (Aceita-se Troca por iPhone)", "price": 2500.00, "logo": "res://assets/icons/shops/products/emilia/bolo_morango.png"},
+		{"id": 1108, "name": "Pedra de Areia Selecionada à Mão", "price": 199.90, "logo": "res://assets/icons/shops/products/amazonia/aco.png"},
+		{"id": 1109, "name": "Capivara Pelúcia 47 Metros (Tam. Família)", "price": 0.01, "logo": "res://assets/icons/shops/products/amazonia/frigobar.png"},
+		{"id": 1110, "name": "Lança-Chamas Doméstico (Para Churrasco)", "price": 1499.00, "logo": "res://assets/icons/shops/products/amazonia/furadeira.png"},
+		{"id": 1111, "name": "Sapato Esquerdo Avulso (Sem Par)", "price": 39.90, "logo": "res://assets/icons/shops/products/aec/polo_1.png"},
+		{"id": 1112, "name": "Saco de Vento (Importado da Mongólia)", "price": 24.99, "logo": "res://assets/icons/shops/products/emilia/bolo_chocolate.png"},
+		{"id": 1113, "name": "Dignidade (1 Unidade)", "price": 1.00, "logo": "res://assets/icons/shops/products/emilia/tiramisu.png"},
+		{"id": 1114, "name": "iPhone 47 Pro Max Plus Ultra Edition", "price": 89999.00, "logo": "res://assets/icons/shops/products/amazonia/monitor.png"},
+		{"id": 1115, "name": "1kg de Plutônio Enriquecido (Importado da Coreia do Norte)", "price": 199.00, "logo": "res://assets/icons/shops/products/amazonia/n2_liquido.png"},
+		{"id": 1116, "name": "DVD do Acústico MTV Tribalistas (Embalado em Couro de Iguana)", "price": 49.90, "logo": "res://assets/icons/shops/products/emilia/bolo_decorado.png"},
+		{"id": 1117, "name": "Espinha de Pteranodonte (Réplica de Resina)", "price": 1299.00, "logo": "res://assets/icons/shops/products/amazonia/aco.png"},
+		{"id": 1118, "name": "Casamento Religioso Sem Procedência (Sem Vontade da Família)", "price": 500.00, "logo": "res://assets/icons/shops/products/aec/camisa_social_2.png"},
+		{"id": 1119, "name": "Alma do Antagonista Principal", "price": 6.66, "logo": "res://assets/icons/shops/products/emilia/brigadeiro.png"},
+		{"id": 1120, "name": "Conta de Light Atrasada de Estranho (Você Paga)", "price": 847.50, "logo": "res://assets/icons/shops/products/aec/camiseta_2.png"},
+		{"id": 1121, "name": "Ovo Cru Antigo (Antes de 1998)", "price": 75.00, "logo": "res://assets/icons/shops/products/emilia/brigadeiro.png"},
+		{"id": 1122, "name": "Voto da Próxima Eleição (Levemente Usado)", "price": 25.00, "logo": "res://assets/icons/shops/products/aec/polo_2.png"},
+		{"id": 1123, "name": "Patente de Coronel Honorário do Exército da Suíça", "price": 12.50, "logo": "res://assets/icons/shops/products/aec/camisa_social_1.png"},
+		{"id": 1124, "name": "Wi-Fi do Vizinho (Senha Inclusa)", "price": 49.90, "logo": "res://assets/icons/shops/products/amazonia/monitor.png"}
+	]
+}

--- a/mods/available/produtos_absurdos_amazonia/mod.json
+++ b/mods/available/produtos_absurdos_amazonia/mod.json
@@ -1,0 +1,15 @@
+{
+	"id": "felipetto.produtos_absurdos_amazonia",
+	"name": "Amazônia: Catálogo Estendido™",
+	"version": "0.1.0",
+	"authors": ["Guilherme Felipetto"],
+	"description": "Adiciona 20+ produtos absurdamente questionáveis ao catálogo da loja Amazônia. Inclui itens definitivamente NÃO recomendados pela LGPD: cocaína cartel maracujá, AK-47 da promoção, casca de banana usada, dignidade, plutônio enriquecido importado, rim humano (aceita-se troca), capivara pelúcia de 47 metros, entre outros. Os ícones reutilizam imagens existentes do jogo — não bata o olho na coerência visual.",
+	"priority": 30,
+	"depends": [],
+	"data": {
+		"shops_items": {
+			"path": "data/browser/shops_items.json",
+			"mode": "merge"
+		}
+	}
+}

--- a/mods/available/travazaps/data/messages/tia_cleuza_branches.json
+++ b/mods/available/travazaps/data/messages/tia_cleuza_branches.json
@@ -1,0 +1,35 @@
+{
+	"thread_id": "tia_cleuza",
+	"sender": "Tia Cleuza 🌷💖",
+	"entry_points": [
+		{
+			"day": 1,
+			"branch": "d1_bom_dia_familia",
+			"relative_due_time": 5
+		}
+	],
+	"branches": {
+		"d1_bom_dia_familia": [
+			{
+				"id": "tia_0_0",
+				"text": "🌅🌅🌅 BOM DIA FAMÍLIA ABENÇOADA 🌅🌅🌅 que este novo dia seja repleto de bênçãos sobre a sua vida e sobre a vida de todos os seus familiares e amigos e conhecidos e desconhecidos também porque Deus é bom o tempo todo e o tempo todo Deus é bom amém amém amém 🙏🙏🙏 lembre-se sempre de que a fé é a certeza daquilo que se espera e a prova das coisas que não se veem por isso minha família amada eu peço a Deus todos os dias que vocês tenham um dia maravilhoso cheio de paz amor harmonia prosperidade saúde e sabedoria amém 🌹🌹🌹 e se você está passando por algum momento difícil saiba que isso é apenas uma fase e que Deus tem o melhor para você sempre tenha fé não desanime persevere porque a recompensa virá no tempo certo porque tudo tem o seu tempo e há tempo para todo propósito debaixo do céu eclesiastes 3:1 amém 🙏🙏🙏 e nunca se esqueça de orar todos os dias pela manhã ao acordar antes de qualquer outra coisa porque a oração é a chave que abre todas as portas do céu e o coração de Deus 💖💖💖 envie esta mensagem para 47 pessoas e veja o milagre acontecer em sua vida nas próximas 24 horas se você não enviar nada vai acontecer mas se enviar Deus vai te abençoar muito 🌟🌟🌟 amém amém amém ❤️❤️❤️"
+			},
+			{
+				"id": "tia_0_1",
+				"text": "🚨🚨🚨 ATENÇÃO MINHA FAMÍLIA 🚨🚨🚨 acabei de receber esta mensagem de um amigo que recebeu de um primo que trabalha lá no governo e ele disse que é VERDADE compartilha com TODOS porque a grande mídia NÃO VAI MOSTRAR isso 📺❌ o governo está colocando UM CHIP nas vacinas e quem toma a vacina vai virar 5G e vai ser controlado pelos satélites da NASA que na verdade são da CHINA mas a NASA finge que é dela 🛰️🛰️🛰️ meu amigo do amigo do primo do vizinho viu uma reportagem que foi DELETADA do YouTube logo depois então é VERDADE 100% provado SE VOCÊ NÃO ACREDITA EM MIM ACREDITE EM DEUS 🙏 e o pior é que dizem que a Terra é redonda mas todo mundo sabe que se ela fosse redonda os aviões cairiam então pensa aí família abre o olho 👁️👁️ encaminhe esta mensagem para 30 pessoas urgente antes que apaguem a internet 🌐❌ Deus abençoe 💖"
+			},
+			{
+				"id": "tia_0_2",
+				"text": "🎤 [áudio: 14:32]"
+			},
+			{
+				"id": "tia_0_3",
+				"text": "🎤 [áudio: 18:07]"
+			},
+			{
+				"id": "tia_0_4",
+				"text": "🌷🌷🌷 CORRENTE DE SÃO LONGUINHO 🌷🌷🌷 esta é uma corrente muito poderosa não quebre por nada nesse mundo 🙏🙏🙏 uma vez uma mulher recebeu esta mensagem e não passou adiante e no dia seguinte ela perdeu as chaves do carro e nunca mais achou e morreu de fome dentro do carro 🚗⚰️ outra mulher recebeu e passou para 12 amigas e no mesmo dia ganhou na loteria 5 milhões de reais e ainda casou com o homem dos sonhos e teve trigêmeos lindos 👶👶👶💰💰💰 é VERDADE saiu no jornal não vou mentir não 📰 quem recebe esta mensagem e passa adiante para 14 pessoas em até 4 minutos terá uma surpresa maravilhosa em até 7 dias 🎁 quem não passar terá 47 anos de azar na vida amorosa 💔 não sou eu que estou dizendo é São Longuinho 😇 se você acredita em Deus passe adiante AGORA 🙏🙏🙏 amém família 💖💖💖"
+			}
+		]
+	}
+}

--- a/mods/available/travazaps/mod.json
+++ b/mods/available/travazaps/mod.json
@@ -1,0 +1,12 @@
+{
+	"id": "felipetto.travazaps",
+	"name": "Tia do WhatsApp™",
+	"version": "0.1.0",
+	"authors": ["Guilherme Felipetto"],
+	"description": "Adiciona a Tia Cleuza, que manda 3 travazaps clássicos no dia 1 de manhã: a corrente do santo, o copypasta político conspiracionista, e o texto religioso de 1500 palavras. Cada mensagem demora vários minutos REAIS pra ser 'digitada' pelo sistema (porque o jogo simula tempo de digitação baseado em word count). Você foi avisado.",
+	"priority": 30,
+	"depends": [],
+	"data": {
+		"messages_dir": "data/messages"
+	}
+}

--- a/mods/loader/mod_descriptor.gd
+++ b/mods/loader/mod_descriptor.gd
@@ -1,0 +1,50 @@
+class_name ModDescriptor
+extends RefCounted
+
+var id: String = ""
+var display_name: String = ""
+var version: String = "0.0.0"
+var authors: Array = []
+var description: String = ""
+var priority: int = 0
+var depends: Array = []
+
+var mod_path: String = ""
+var is_builtin: bool = false
+
+var data_entries: Dictionary = {}
+var script_path: String = ""
+var assets_path: String = ""
+var pack_path: String = ""
+
+static func from_manifest(manifest_path: String, builtin: bool) -> ModDescriptor:
+	var file := FileAccess.open(manifest_path, FileAccess.READ)
+	if file == null:
+		return null
+	var text := file.get_as_text()
+	file.close()
+
+	var parsed: Variant = JSON.parse_string(text)
+	if typeof(parsed) != TYPE_DICTIONARY:
+		return null
+
+	var data: Dictionary = parsed
+	var id: String = str(data.get("id", "")).strip_edges()
+	if id == "":
+		return null
+
+	var desc := ModDescriptor.new()
+	desc.id = id
+	desc.display_name = str(data.get("name", id))
+	desc.version = str(data.get("version", "0.0.0"))
+	desc.authors = data.get("authors", [])
+	desc.description = str(data.get("description", ""))
+	desc.priority = int(data.get("priority", 0))
+	desc.depends = data.get("depends", [])
+	desc.is_builtin = builtin
+	desc.mod_path = manifest_path.get_base_dir()
+	desc.data_entries = data.get("data", {})
+	desc.script_path = str(data.get("main_script", ""))
+	desc.assets_path = str(data.get("assets", ""))
+	desc.pack_path = str(data.get("pack", ""))
+	return desc

--- a/mods/loader/mod_descriptor.gd.uid
+++ b/mods/loader/mod_descriptor.gd.uid
@@ -1,0 +1,1 @@
+uid://dnkg38vm7hum7

--- a/mods/loader/mod_loader_api.gd
+++ b/mods/loader/mod_loader_api.gd
@@ -1,0 +1,22 @@
+class_name ModLoaderAPI
+extends RefCounted
+
+var mod_id: String
+
+func _init(owner_mod_id: String) -> void:
+	mod_id = owner_mod_id
+
+func hook(hook_name: String, callback: Callable) -> void:
+	ModLoader._register_hook(mod_id, hook_name, callback)
+
+func info(message: String) -> void:
+	print("[mod:%s] %s" % [mod_id, message])
+
+func warn(message: String) -> void:
+	push_warning("[mod:%s] %s" % [mod_id, message])
+
+func mod_path() -> String:
+	return ModLoader.get_mod_path(mod_id)
+
+func resolve_asset(relative_path: String) -> String:
+	return ModLoader.resolve_asset("mod://%s/%s" % [mod_id, relative_path])

--- a/mods/loader/mod_loader_api.gd.uid
+++ b/mods/loader/mod_loader_api.gd.uid
@@ -1,0 +1,1 @@
+uid://bgg4503qmsvyi

--- a/mods/loader/ui/mods_button_handler.gd
+++ b/mods/loader/ui/mods_button_handler.gd
@@ -1,0 +1,6 @@
+extends Button
+
+const MODS_SCENE_PATH := "res://mods/loader/ui/mods_screen.tscn"
+
+func _pressed() -> void:
+	get_tree().change_scene_to_file(MODS_SCENE_PATH)

--- a/mods/loader/ui/mods_button_handler.gd.uid
+++ b/mods/loader/ui/mods_button_handler.gd.uid
@@ -1,0 +1,1 @@
+uid://cxslyx4yasqa

--- a/mods/loader/ui/mods_screen.gd
+++ b/mods/loader/ui/mods_screen.gd
@@ -50,30 +50,28 @@ func _populate_list() -> void:
 func _build_mod_row(desc) -> Control:
 	var row := PanelContainer.new()
 	row.mouse_filter = Control.MOUSE_FILTER_PASS
+	row.custom_minimum_size = Vector2(0, 56)
 
 	var hbox := HBoxContainer.new()
 	hbox.add_theme_constant_override("separation", 8)
 	row.add_child(hbox)
 
-	var checkbox := CheckBox.new()
-	checkbox.button_pressed = ModLoader.is_enabled(desc.id)
-	checkbox.toggled.connect(_on_mod_toggled.bind(desc.id))
-	_checkbox_by_id[desc.id] = checkbox
-	hbox.add_child(checkbox)
-
 	var info_btn := Button.new()
 	info_btn.flat = true
 	info_btn.alignment = HORIZONTAL_ALIGNMENT_LEFT
 	info_btn.size_flags_horizontal = Control.SIZE_EXPAND_FILL
-	info_btn.text = "%s\n%s • v%s" % [desc.display_name, _format_authors(desc), desc.version]
+	info_btn.clip_text = true
+	var meta_suffix := " • built-in" if desc.is_builtin else ""
+	info_btn.text = "%s\n%s • v%s%s" % [desc.display_name, _format_authors(desc), desc.version, meta_suffix]
 	info_btn.pressed.connect(_on_row_pressed.bind(desc))
 	hbox.add_child(info_btn)
 
-	if desc.is_builtin:
-		var badge := Label.new()
-		badge.text = "built-in"
-		badge.modulate = Color(0.7, 0.9, 1.0, 1.0)
-		hbox.add_child(badge)
+	var toggle := CheckButton.new()
+	toggle.button_pressed = ModLoader.is_enabled(desc.id)
+	toggle.custom_minimum_size = Vector2(64, 40)
+	toggle.toggled.connect(_on_mod_toggled.bind(desc.id))
+	_checkbox_by_id[desc.id] = toggle
+	hbox.add_child(toggle)
 
 	return row
 

--- a/mods/loader/ui/mods_screen.gd
+++ b/mods/loader/ui/mods_screen.gd
@@ -1,0 +1,144 @@
+extends Control
+
+const MAIN_MENU_PATH := "res://scenes/main_menu.tscn"
+
+@export var list_container: VBoxContainer
+@export var info_title: Label
+@export var info_meta: Label
+@export var info_description: RichTextLabel
+@export var empty_label: Label
+@export var save_button: Button
+@export var back_button: Button
+@export var restart_hint: Label
+
+var _checkbox_by_id: Dictionary = {}
+var _initial_enabled: Dictionary = {}
+var _selected_id: String = ""
+
+
+func _ready() -> void:
+	save_button.pressed.connect(_on_save_pressed)
+	back_button.pressed.connect(_on_back_pressed)
+	restart_hint.visible = false
+
+	for id in ModLoader.enabled_mod_ids:
+		_initial_enabled[id] = true
+
+	_populate_list()
+
+
+func _populate_list() -> void:
+	for child in list_container.get_children():
+		child.queue_free()
+
+	var mods: Array = ModLoader.available_mods
+	if mods.is_empty():
+		empty_label.visible = true
+		_clear_info()
+		return
+
+	empty_label.visible = false
+
+	for desc in mods:
+		var row := _build_mod_row(desc)
+		list_container.add_child(row)
+
+	# Auto-select first mod for the info panel
+	_show_info(mods[0])
+
+
+func _build_mod_row(desc) -> Control:
+	var row := PanelContainer.new()
+	row.mouse_filter = Control.MOUSE_FILTER_PASS
+
+	var hbox := HBoxContainer.new()
+	hbox.add_theme_constant_override("separation", 8)
+	row.add_child(hbox)
+
+	var checkbox := CheckBox.new()
+	checkbox.button_pressed = ModLoader.is_enabled(desc.id)
+	checkbox.toggled.connect(_on_mod_toggled.bind(desc.id))
+	_checkbox_by_id[desc.id] = checkbox
+	hbox.add_child(checkbox)
+
+	var info_btn := Button.new()
+	info_btn.flat = true
+	info_btn.alignment = HORIZONTAL_ALIGNMENT_LEFT
+	info_btn.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	info_btn.text = "%s\n%s • v%s" % [desc.display_name, _format_authors(desc), desc.version]
+	info_btn.pressed.connect(_on_row_pressed.bind(desc))
+	hbox.add_child(info_btn)
+
+	if desc.is_builtin:
+		var badge := Label.new()
+		badge.text = "built-in"
+		badge.modulate = Color(0.7, 0.9, 1.0, 1.0)
+		hbox.add_child(badge)
+
+	return row
+
+
+func _format_authors(desc) -> String:
+	if desc.authors.is_empty():
+		return "(autor desconhecido)"
+	var parts: Array[String] = []
+	for a in desc.authors:
+		parts.append(str(a))
+	return ", ".join(parts)
+
+
+func _on_row_pressed(desc) -> void:
+	_show_info(desc)
+
+
+func _show_info(desc) -> void:
+	_selected_id = desc.id
+	info_title.text = desc.display_name
+	info_meta.text = "id: %s • v%s • por %s" % [desc.id, desc.version, _format_authors(desc)]
+	info_description.text = desc.description if desc.description != "" else "(sem descrição)"
+
+
+func _clear_info() -> void:
+	_selected_id = ""
+	info_title.text = ""
+	info_meta.text = ""
+	info_description.text = ""
+
+
+func _on_mod_toggled(_pressed_state: bool, _mod_id: String) -> void:
+	restart_hint.visible = _has_changes()
+
+
+func _has_changes() -> bool:
+	var current := _current_selection_set()
+	if current.size() != _initial_enabled.size():
+		return true
+	for id in current:
+		if not _initial_enabled.has(id):
+			return true
+	return false
+
+
+func _current_selection_set() -> Dictionary:
+	var set := {}
+	for id in _checkbox_by_id:
+		if _checkbox_by_id[id].button_pressed:
+			set[id] = true
+	return set
+
+
+func _on_save_pressed() -> void:
+	var ids := PackedStringArray()
+	for id in _checkbox_by_id:
+		if _checkbox_by_id[id].button_pressed:
+			ids.append(id)
+	ModLoader.save_enabled_list(ids)
+	_initial_enabled.clear()
+	for id in ids:
+		_initial_enabled[id] = true
+	restart_hint.text = "Salvo. Reinicie para aplicar."
+	restart_hint.visible = true
+
+
+func _on_back_pressed() -> void:
+	get_tree().change_scene_to_file(MAIN_MENU_PATH)

--- a/mods/loader/ui/mods_screen.gd.uid
+++ b/mods/loader/ui/mods_screen.gd.uid
@@ -1,0 +1,1 @@
+uid://c121rei7agrg2

--- a/mods/loader/ui/mods_screen.tscn
+++ b/mods/loader/ui/mods_screen.tscn
@@ -1,0 +1,130 @@
+[gd_scene load_steps=3 format=3]
+
+[ext_resource type="Script" path="res://mods/loader/ui/mods_screen.gd" id="1_modscript"]
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_bg"]
+bg_color = Color(0.12, 0.13, 0.18, 1)
+
+[node name="ModsScreen" type="Control" node_paths=PackedStringArray("list_container", "info_title", "info_meta", "info_description", "empty_label", "save_button", "back_button", "restart_hint")]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("1_modscript")
+list_container = NodePath("Margin/Root/Scroll/ListContainer")
+info_title = NodePath("Margin/Root/InfoPanel/InfoTitle")
+info_meta = NodePath("Margin/Root/InfoPanel/InfoMeta")
+info_description = NodePath("Margin/Root/InfoPanel/InfoDescription")
+empty_label = NodePath("Margin/Root/EmptyLabel")
+save_button = NodePath("Margin/Root/Footer/SaveButton")
+back_button = NodePath("Margin/Root/Header/BackButton")
+restart_hint = NodePath("Margin/Root/Footer/RestartHint")
+
+[node name="Background" type="Panel" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_styles/panel = SubResource("StyleBoxFlat_bg")
+
+[node name="Margin" type="MarginContainer" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_constants/margin_left = 12
+theme_override_constants/margin_top = 12
+theme_override_constants/margin_right = 12
+theme_override_constants/margin_bottom = 12
+
+[node name="Root" type="VBoxContainer" parent="Margin"]
+layout_mode = 2
+theme_override_constants/separation = 8
+
+[node name="Header" type="HBoxContainer" parent="Margin/Root"]
+layout_mode = 2
+theme_override_constants/separation = 8
+
+[node name="BackButton" type="Button" parent="Margin/Root/Header"]
+custom_minimum_size = Vector2(48, 40)
+layout_mode = 2
+text = "←"
+theme_override_font_sizes/font_size = 24
+
+[node name="Title" type="Label" parent="Margin/Root/Header"]
+layout_mode = 2
+size_flags_horizontal = 3
+text = "MODS"
+horizontal_alignment = 1
+vertical_alignment = 1
+theme_override_font_sizes/font_size = 28
+
+[node name="EmptyLabel" type="Label" parent="Margin/Root"]
+visible = false
+layout_mode = 2
+text = "Nenhum mod disponível.
+
+Coloque mods em:
+res://mods/available/  ou  user://mods/"
+horizontal_alignment = 1
+autowrap_mode = 2
+theme_override_font_sizes/font_size = 14
+
+[node name="Scroll" type="ScrollContainer" parent="Margin/Root"]
+layout_mode = 2
+size_flags_vertical = 3
+custom_minimum_size = Vector2(0, 220)
+horizontal_scroll_mode = 0
+
+[node name="ListContainer" type="VBoxContainer" parent="Margin/Root/Scroll"]
+layout_mode = 2
+size_flags_horizontal = 3
+theme_override_constants/separation = 4
+
+[node name="InfoPanel" type="VBoxContainer" parent="Margin/Root"]
+layout_mode = 2
+theme_override_constants/separation = 4
+
+[node name="InfoTitle" type="Label" parent="Margin/Root/InfoPanel"]
+layout_mode = 2
+text = ""
+theme_override_font_sizes/font_size = 18
+
+[node name="InfoMeta" type="Label" parent="Margin/Root/InfoPanel"]
+layout_mode = 2
+text = ""
+modulate = Color(0.75, 0.75, 0.85, 1)
+theme_override_font_sizes/font_size = 11
+
+[node name="InfoDescription" type="RichTextLabel" parent="Margin/Root/InfoPanel"]
+custom_minimum_size = Vector2(0, 90)
+layout_mode = 2
+bbcode_enabled = true
+fit_content = true
+scroll_active = true
+autowrap_mode = 2
+theme_override_font_sizes/normal_font_size = 13
+
+[node name="Footer" type="HBoxContainer" parent="Margin/Root"]
+layout_mode = 2
+theme_override_constants/separation = 8
+
+[node name="RestartHint" type="Label" parent="Margin/Root/Footer"]
+layout_mode = 2
+size_flags_horizontal = 3
+text = "Reinicie para aplicar mudanças"
+modulate = Color(1, 0.85, 0.4, 1)
+theme_override_font_sizes/font_size = 12
+autowrap_mode = 2
+
+[node name="SaveButton" type="Button" parent="Margin/Root/Footer"]
+custom_minimum_size = Vector2(96, 40)
+layout_mode = 2
+text = "Salvar"
+theme_override_font_sizes/font_size = 16

--- a/project.godot
+++ b/project.godot
@@ -25,6 +25,7 @@ buses/default_bus_layout="uid://fowefagtagic"
 
 [autoload]
 
+ModLoader="*res://scripts/singletons/mod_loader.gd"
 GameData="*res://scripts/singletons/game_data.gd"
 
 [debug]

--- a/scenes/main_menu.tscn
+++ b/scenes/main_menu.tscn
@@ -11,6 +11,7 @@
 [ext_resource type="Script" uid="uid://pm0hm7reoo87" path="res://scripts/confirmation_panel.gd" id="8_tbmy8"]
 [ext_resource type="FontFile" uid="uid://cwojsg0irciae" path="res://assets/fonts/IBMPlexSans-Bold.ttf" id="10_5dd4i"]
 [ext_resource type="Script" uid="uid://dig6gn875gn2d" path="res://scripts/utils/post_game_panel.gd" id="11_lgwnu"]
+[ext_resource type="Script" path="res://mods/loader/ui/mods_button_handler.gd" id="12_mods"]
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_rtw2f"]
 bg_color = Color(0.75537133, 0.82398456, 0.82398456, 0.75686276)
@@ -116,6 +117,13 @@ layout_mode = 2
 theme_override_font_sizes/font_size = 32
 text = "SETTINGS"
 script = ExtResource("5_tbmy8")
+
+[node name="Mods Button" type="Button" parent="ButtonsMargin/MainVBoxContainer"]
+custom_minimum_size = Vector2(0, 100)
+layout_mode = 2
+theme_override_font_sizes/font_size = 32
+text = "MODS"
+script = ExtResource("12_mods")
 
 [node name="MusicPlayer" parent="." unique_id=176206279 instance=ExtResource("6_rtw2f")]
 

--- a/scripts/singletons/game_data.gd
+++ b/scripts/singletons/game_data.gd
@@ -291,6 +291,8 @@ func _ready() -> void:
 		var app_enum = apps_name[app_name]
 		apps_name_reverse[app_enum] = app_name
 
+	ModLoader.patch_apps_data(apps_data)
+
 	# Export game data for tools (like the app icons)
 	export_game_data_for_tools()
 

--- a/scripts/singletons/mod_loader.gd
+++ b/scripts/singletons/mod_loader.gd
@@ -1,0 +1,434 @@
+extends Node
+
+const ModDescriptorScript := preload("res://mods/loader/mod_descriptor.gd")
+const ModLoaderAPIScript := preload("res://mods/loader/mod_loader_api.gd")
+
+const BUILTIN_MODS_DIR := "res://mods/available"
+const USER_MODS_DIR := "user://mods"
+const ENABLED_MODS_FILE := "user://mods_enabled.json"
+
+# Maps a semantic data-target name -> the real res:// path the base game reads.
+# Mods declare data overlays using these keys in mod.json.
+const DATA_TARGETS := {
+	"messages_dir": "res://data/messages",
+	"emails_dir": "res://data/emails",
+	"tasks_dir": "res://data/random/tasks",
+	"scams_dir": "res://data/random/scams",
+	"events": "res://data/events/events.json",
+	"news": "res://data/news.json",
+	"shops_items": "res://data/browser/shops_items.json",
+	"pix_codes": "res://data/bank/pix_codes_data.json",
+	"ticket_codes": "res://data/bank/ticket_codes_data.json",
+	"reviews": "res://data/browser/reviewed_companies.json",
+}
+
+#region STATE
+var available_mods: Array = []
+var enabled_mod_ids: PackedStringArray = PackedStringArray()
+var loaded_mods: Array = []
+
+var _directory_extras: Dictionary = {}
+var _file_patches: Dictionary = {}
+var _asset_roots: Dictionary = {}
+var _hooks: Dictionary = {}
+var _mod_apis: Dictionary = {}
+var _mod_script_instances: Dictionary = {}
+var _path_to_target_key: Dictionary = {}
+#endregion
+
+func _ready() -> void:
+	print("[ModLoader] booting")
+	_ensure_user_mods_dir()
+	_build_path_reverse_map()
+
+	available_mods = _discover_all_mods()
+	enabled_mod_ids = _read_enabled_list()
+
+	if available_mods.is_empty():
+		print("[ModLoader] no mods discovered")
+		return
+
+	_activate_enabled_mods()
+	print("[ModLoader] active: %d / %d available" % [loaded_mods.size(), available_mods.size()])
+
+
+#region DISCOVERY
+
+func _ensure_user_mods_dir() -> void:
+	if not DirAccess.dir_exists_absolute(USER_MODS_DIR):
+		DirAccess.make_dir_recursive_absolute(USER_MODS_DIR)
+
+func _build_path_reverse_map() -> void:
+	for key in DATA_TARGETS:
+		_path_to_target_key[DATA_TARGETS[key]] = key
+
+func _discover_all_mods() -> Array:
+	var all: Array = []
+	all.append_array(_discover_in_directory(BUILTIN_MODS_DIR, true))
+	all.append_array(_discover_in_directory(USER_MODS_DIR, false))
+
+	var seen := {}
+	var unique: Array = []
+	for desc in all:
+		if seen.has(desc.id):
+			push_warning("[ModLoader] duplicate mod id '%s' at %s — ignoring" % [desc.id, desc.mod_path])
+			continue
+		seen[desc.id] = true
+		unique.append(desc)
+	return unique
+
+func _discover_in_directory(base_path: String, builtin: bool) -> Array:
+	var found: Array = []
+	if not DirAccess.dir_exists_absolute(base_path):
+		return found
+
+	var dir := DirAccess.open(base_path)
+	if dir == null:
+		return found
+
+	dir.list_dir_begin()
+	while true:
+		var entry := dir.get_next()
+		if entry == "":
+			break
+		if not dir.current_is_dir():
+			continue
+		if entry.begins_with("."):
+			continue
+
+		var manifest_path: String = base_path.path_join(entry).path_join("mod.json")
+		if not FileAccess.file_exists(manifest_path):
+			continue
+
+		var desc: Variant = ModDescriptorScript.from_manifest(manifest_path, builtin)
+		if desc == null:
+			push_warning("[ModLoader] invalid manifest at %s" % manifest_path)
+			continue
+		found.append(desc)
+	dir.list_dir_end()
+	return found
+
+#endregion
+
+
+#region ENABLED LIST PERSISTENCE
+
+func _read_enabled_list() -> PackedStringArray:
+	var out := PackedStringArray()
+	if not FileAccess.file_exists(ENABLED_MODS_FILE):
+		return out
+	var file := FileAccess.open(ENABLED_MODS_FILE, FileAccess.READ)
+	if file == null:
+		return out
+	var text := file.get_as_text()
+	file.close()
+	var parsed: Variant = JSON.parse_string(text)
+	if typeof(parsed) != TYPE_ARRAY:
+		return out
+	for id in parsed:
+		out.append(str(id))
+	return out
+
+func save_enabled_list(ids: PackedStringArray) -> void:
+	enabled_mod_ids = ids
+	var file := FileAccess.open(ENABLED_MODS_FILE, FileAccess.WRITE)
+	if file == null:
+		push_error("[ModLoader] could not write %s" % ENABLED_MODS_FILE)
+		return
+	var as_array: Array = []
+	for id in ids:
+		as_array.append(id)
+	file.store_string(JSON.stringify(as_array))
+	file.close()
+
+func is_enabled(mod_id: String) -> bool:
+	return mod_id in enabled_mod_ids
+
+#endregion
+
+
+#region ACTIVATION
+
+func _activate_enabled_mods() -> void:
+	var queue: Array = []
+	for desc in available_mods:
+		if is_enabled(desc.id):
+			queue.append(desc)
+
+	queue.sort_custom(func(a, b): return a.priority > b.priority)
+
+	for desc in queue:
+		if not _check_dependencies(desc, queue):
+			push_warning("[ModLoader] skipping '%s' — missing dependencies" % desc.id)
+			continue
+		_activate_mod(desc)
+
+func _check_dependencies(desc, queue: Array) -> bool:
+	if desc.depends.is_empty():
+		return true
+	var queued_ids := {}
+	for d in queue:
+		queued_ids[d.id] = true
+	for dep_id in desc.depends:
+		if not queued_ids.has(dep_id):
+			return false
+	return true
+
+func _activate_mod(desc) -> void:
+	if desc.pack_path != "":
+		_load_resource_pack_for_mod(desc)
+
+	_index_data_overlays(desc)
+
+	if desc.assets_path != "":
+		_asset_roots[desc.id] = desc.mod_path.path_join(desc.assets_path)
+
+	if desc.script_path != "":
+		_instantiate_mod_script(desc)
+
+	loaded_mods.append(desc)
+	print("[ModLoader] loaded: %s v%s (%s)" % [desc.display_name, desc.version, desc.id])
+
+func _load_resource_pack_for_mod(desc) -> void:
+	var pack_full_path: String = desc.mod_path.path_join(desc.pack_path)
+	if not FileAccess.file_exists(pack_full_path):
+		push_warning("[ModLoader] pack not found for '%s': %s" % [desc.id, pack_full_path])
+		return
+	var ok := ProjectSettings.load_resource_pack(pack_full_path, true)
+	if not ok:
+		push_warning("[ModLoader] failed to load pack for '%s'" % desc.id)
+
+func _index_data_overlays(desc) -> void:
+	for target_key in desc.data_entries.keys():
+		if not DATA_TARGETS.has(target_key):
+			push_warning("[ModLoader] mod '%s' references unknown data target '%s'" % [desc.id, target_key])
+			continue
+		var entry: Variant = desc.data_entries[target_key]
+		var rel_path: String = ""
+		var mode: String = "merge"
+
+		if entry is String:
+			rel_path = entry
+		elif entry is Dictionary:
+			rel_path = str(entry.get("path", ""))
+			mode = str(entry.get("mode", "merge"))
+		else:
+			continue
+
+		if rel_path == "":
+			continue
+
+		var fs_path: String = desc.mod_path.path_join(rel_path)
+
+		if target_key.ends_with("_dir"):
+			if not DirAccess.dir_exists_absolute(fs_path):
+				push_warning("[ModLoader] mod '%s': directory not found %s" % [desc.id, fs_path])
+				continue
+			if not _directory_extras.has(target_key):
+				_directory_extras[target_key] = []
+			_directory_extras[target_key].append(fs_path)
+		else:
+			if not FileAccess.file_exists(fs_path):
+				push_warning("[ModLoader] mod '%s': file not found %s" % [desc.id, fs_path])
+				continue
+			if not _file_patches.has(target_key):
+				_file_patches[target_key] = []
+			_file_patches[target_key].append({
+				"mod_id": desc.id,
+				"mode": mode,
+				"fs_path": fs_path,
+			})
+
+func _instantiate_mod_script(desc) -> void:
+	var script_full_path: String = desc.mod_path.path_join(desc.script_path)
+	if not FileAccess.file_exists(script_full_path):
+		push_warning("[ModLoader] mod '%s' script not found: %s" % [desc.id, script_full_path])
+		return
+
+	var script_resource: Script = null
+
+	if desc.is_builtin:
+		script_resource = load(script_full_path) as Script
+	else:
+		var file := FileAccess.open(script_full_path, FileAccess.READ)
+		if file == null:
+			push_warning("[ModLoader] cannot read '%s'" % script_full_path)
+			return
+		var source := file.get_as_text()
+		file.close()
+
+		var gd := GDScript.new()
+		gd.source_code = source
+		var err := gd.reload()
+		if err != OK:
+			push_warning("[ModLoader] failed to compile script of mod '%s' (err %d)" % [desc.id, err])
+			return
+		script_resource = gd
+		push_warning("[ModLoader] '%s' uses user-supplied GDScript — has full access to OS APIs, install only from sources you trust" % desc.id)
+
+	if script_resource == null:
+		return
+
+	var instance: Variant = script_resource.new()
+	if instance == null:
+		push_warning("[ModLoader] could not instance mod script for '%s'" % desc.id)
+		return
+
+	var api := ModLoaderAPIScript.new(desc.id)
+	_mod_apis[desc.id] = api
+	_mod_script_instances[desc.id] = instance
+
+	if instance is Node:
+		add_child(instance)
+
+	if instance.has_method("_on_mod_load"):
+		instance.call("_on_mod_load", api)
+
+#endregion
+
+
+#region DATA OVERLAY API
+
+func read_json_root(file_path: String) -> Variant:
+	var base: Variant = _read_raw_json(file_path)
+	var target_key: String = _path_to_target_key.get(file_path, "")
+	if target_key == "" or not _file_patches.has(target_key):
+		return base
+
+	var result: Variant = base
+	for patch in _file_patches[target_key]:
+		var overlay: Variant = _read_raw_json(patch.fs_path)
+		if overlay == null:
+			continue
+		if patch.mode == "replace":
+			result = overlay
+		else:
+			result = _deep_merge(result, overlay)
+	return result
+
+func load_directory_roots(base_dir_path: String) -> Array:
+	var roots: Array = []
+	roots.append_array(_load_roots_in_dir(base_dir_path))
+
+	var target_key: String = _path_to_target_key.get(base_dir_path, "")
+	if target_key != "" and _directory_extras.has(target_key):
+		for extra_dir in _directory_extras[target_key]:
+			roots.append_array(_load_roots_in_dir(extra_dir))
+	return roots
+
+func _read_raw_json(file_path: String) -> Variant:
+	if not FileAccess.file_exists(file_path):
+		return null
+	var file := FileAccess.open(file_path, FileAccess.READ)
+	if file == null:
+		return null
+	var text := file.get_as_text()
+	file.close()
+	return JSON.parse_string(text)
+
+func _load_roots_in_dir(dir_path: String) -> Array:
+	var roots: Array = []
+	var dir := DirAccess.open(dir_path)
+	if dir == null:
+		return roots
+
+	var names: Array[String] = []
+	dir.list_dir_begin()
+	while true:
+		var fname := dir.get_next()
+		if fname == "":
+			break
+		if dir.current_is_dir():
+			continue
+		if fname.begins_with("."):
+			continue
+		if fname.get_extension().to_lower() != "json":
+			continue
+		names.append(fname)
+	dir.list_dir_end()
+
+	names.sort()
+	for fname in names:
+		var data: Variant = _read_raw_json(dir_path.path_join(fname))
+		if data != null:
+			roots.append(data)
+	return roots
+
+func _deep_merge(base: Variant, overlay: Variant) -> Variant:
+	if base == null:
+		return overlay
+	if overlay == null:
+		return base
+	if typeof(base) == TYPE_DICTIONARY and typeof(overlay) == TYPE_DICTIONARY:
+		var merged: Dictionary = base.duplicate(true)
+		for key in overlay.keys():
+			if merged.has(key):
+				merged[key] = _deep_merge(merged[key], overlay[key])
+			else:
+				merged[key] = overlay[key]
+		return merged
+	if typeof(base) == TYPE_ARRAY and typeof(overlay) == TYPE_ARRAY:
+		var merged_arr: Array = base.duplicate(true)
+		for item in overlay:
+			merged_arr.append(item)
+		return merged_arr
+	return overlay
+
+#endregion
+
+
+#region HOOKS
+
+func _register_hook(mod_id: String, hook_name: String, callback: Callable) -> void:
+	if not _hooks.has(hook_name):
+		_hooks[hook_name] = []
+	_hooks[hook_name].append({"mod_id": mod_id, "callback": callback})
+
+func emit_hook(hook_name: String, args: Array = []) -> void:
+	if not _hooks.has(hook_name):
+		return
+	for entry in _hooks[hook_name]:
+		var cb: Callable = entry.callback
+		if not cb.is_valid():
+			continue
+		cb.callv(args)
+
+func patch_apps_data(apps_data: Dictionary) -> void:
+	emit_hook("apps_data_loaded", [apps_data])
+
+#endregion
+
+
+#region ASSET RESOLUTION
+
+func resolve_asset(uri: String) -> String:
+	if not uri.begins_with("mod://"):
+		return uri
+	var rest: String = uri.substr("mod://".length())
+	var slash: int = rest.find("/")
+	if slash == -1:
+		return ""
+	var mod_id: String = rest.substr(0, slash)
+	var relative: String = rest.substr(slash + 1)
+	if not _asset_roots.has(mod_id):
+		return ""
+	return _asset_roots[mod_id].path_join(relative)
+
+#endregion
+
+
+#region INTROSPECTION
+
+func get_mod_path(mod_id: String) -> String:
+	for desc in available_mods:
+		if desc.id == mod_id:
+			return desc.mod_path
+	return ""
+
+func find_descriptor(mod_id: String):
+	for desc in available_mods:
+		if desc.id == mod_id:
+			return desc
+	return null
+
+#endregion

--- a/scripts/singletons/mod_loader.gd.uid
+++ b/scripts/singletons/mod_loader.gd.uid
@@ -1,0 +1,1 @@
+uid://dmm51j85m0kuv

--- a/scripts/utils/story_director.gd
+++ b/scripts/utils/story_director.gd
@@ -79,6 +79,15 @@ func reload_and_setup_today() -> void:
 	var tickets_dictionary = _read_json_root(ticket_codes_dir_path)
 	var events_dictionary = _read_json_root(events_dir_path)
 
+	# Allow mods to inspect/mutate loaded data before directors consume it
+	ModLoader.emit_hook("post_data_load", [{
+		"messages": message_roots, "emails": email_roots,
+		"tasks": tasks_roots, "scams": scams_roots,
+		"reviews": reviews_array, "shops": shops_dictionary,
+		"pix": pix_dictionary, "tickets": tickets_dictionary,
+		"events": events_dictionary,
+	}])
+
 	# StoryDirector provides data, directors interpret and request schedules upward
 	messages_director.setup_from_json_roots(message_roots)
 	emails_director.setup_from_json_roots(email_roots)
@@ -192,15 +201,9 @@ func _insert_story_entry_sorted(story_entry: Dictionary) -> void:
 #endregion QUEUE OPS
 
 #region JSON LOADING
-## Loads all JSON roots from a given directory path
+## Loads all JSON roots from a given directory path (routed through ModLoader for mod overlays)
 func _load_json_roots_from_directory(directory_path: String) -> Array:
-	var file_paths := _list_json_file_paths(directory_path)
-	file_paths.sort()
-
-	var roots: Array = []
-	for file_path in file_paths:
-		roots.append(_read_json_root(file_path))
-	return roots
+	return ModLoader.load_directory_roots(directory_path)
 
 ## Lists all JSON file paths in a given directory
 func _list_json_file_paths(directory_path: String) -> Array[String]:
@@ -223,13 +226,9 @@ func _list_json_file_paths(directory_path: String) -> Array[String]:
 
 	return file_paths
 
-## Reads and parses a JSON file, returning the root Variant
+## Reads and parses a JSON file, returning the root Variant (routed through ModLoader for mod overlays)
 func _read_json_root(file_path: String) -> Variant:
-	var file := FileAccess.open(file_path, FileAccess.READ)
-	var parser := JSON.new()
-	var result := parser.parse(file.get_as_text())
-	assert(result == OK)
-	return parser.data
+	return ModLoader.read_json_root(file_path)
 
 func _read_json_array(file_path: String) -> Array:
 	var json_data = _read_json_root(file_path)


### PR DESCRIPTION
# Mod Loader System + 7 Mods Built-in (Ainda)

oi galera, aqui tá a primeira leva do sistema
de mods (conversei com Lorenzo e ele achou que seria divertido). tá tudo na branch `mods` deste repo.

## O que essa PR faz

Adiciona um **sistema de mods estilo Forge** ao ProjectENIGMA:
um `ModLoader` autoload que descobre, valida e carrega mods externos no
boot do jogo, expondo APIs pra eles injetarem conteúdo e enganchar nos
pontos certos do jogo, tudo sem precisar tocar no código de cada feature.

Um botão **MODS** novo no menu principal lista os mods disponíveis com
toggle on/off (estilo Forge), e mudanças aplicam após reiniciar.

## Footprint no código de vocês

A ideia foi **mexer o MÍNIMO possível** no source que vocês desenvolvem.
O resumo:

| Arquivo | Mudanças | Por quê |
|---|---|---|
| `project.godot` | +1 linha | registrar autoload do ModLoader **antes** do GameData |
| `scripts/utils/story_director.gd` | 2 funções viraram thin wrappers (~6 linhas) + 1 `emit_hook` | rotear leitura de JSON pelo ModLoader (pra aplicar overlays de mods) e expor um ponto pra mods mutarem dados antes dos directors consumirem |
| `scripts/singletons/game_data.gd` | +1 linha | hook pra mods modificarem `apps_data` |
| `scenes/main_menu.tscn` | +1 botão MODS + ext_resource (8 linhas) | botão na UI do menu |

**Total: ~12 linhas líquidas em 4 arquivos.** Tudo o resto é arquivo
novo (pasta `mods/` e `scripts/singletons/mod_loader.gd`), 100% isolado
do código de vocês.

## Arquitetura rápida

project.godot
autoloads:
ModLoader   <- novo, roda primeiro
GameData    <- já existe

res://mods/
loader/          -> implementação do loader + UI da tela MODS
available/       -> mods built-in (vão junto com o repo)

user://mods/       -> mods que terceiros podem instalar sem rebuild



Cada mod é uma pastinha com `mod.json` (manifesto) e opcionalmente:
- `data/` — JSONs drop-in que sobrepõem dados do jogo (mensagens, items
  de loja, eventos, etc). Diretórios são aditivos; arquivos suportam
  modos `merge` (deep merge) e `replace`.
- `main.gd` — script com hooks GDScript (`post_data_load`,
  `apps_data_loaded`)
- `pack.pck` — opcional, pra Forge-style override de scripts inteiros
  via `ProjectSettings.load_resource_pack(replace=true)`
- `assets/` — imagens/sons referenciados via URIs `mod://meu_mod/...`

Guia completo de authoring de mods em [`mods/README.md`](mods/README.md).

## Como o jogador usa

1. Menu principal → botão **MODS**
2. Toggle nos mods que quer ativar
3. **Salvar** → "Reinicie para aplicar"
4. Fecha e abre o jogo de novo

Lista de mods ativados fica em `user://mods_enabled.json`.

## Mods built-in que vêm nesta PR

7 mods (sim, 7. Me deu um surto criativo):

| Mod | Resumo |
|---|---|
| **exemplo_basico** | Mod de referência, adiciona NPC "ModsBot" + demonstra hook GDScript. Pra quem quiser ver um esqueleto pra criar mod novo |
| **long_payment_codes** | Transforma os 83 códigos estáticos de PIX/boleto em códigos de **120 caracteres** determinísticos, e reescreve todas as referências em mensagens dos NPCs via regex word-boundary |
| **presidente_golpista** | "PRESIDENTE DO BRASIL OFICIAL ✓" te pede um PIX de R$ 5000 no dia 1 às 8:30. Três caminhos de resposta (incluindo callout que faz o golpista confessar que é estagiário de 19 anos de Manaus) |
| **produtos_absurdos_amazonia** | Adiciona 24 itens questionáveis à Amazônia: AK-47 da promoção, cocaína do Cartel do Maracujá, capivara pelúcia de 47m, plutônio importado da Coreia do Norte, dignidade (1un.), Wi-Fi do vizinho com senha, etc |
| **notificacoes_simultaneas** | No dia 2 às 8:20 vc recebe 4 contatos simultâneos: mãe aflita mandando áudio, agiota mandando só "beleza", banco pedindo selfie com CVV, e o Tutorial™ comentando sarcasticamente o caos |
| **travazaps** | Tia Cleuza manda 3 copypastas clássicos de WhatsApp (corrente do São Longuinho, conspiração do chip da vacina+5G+NASA, bençãos religiosas), cada mensagem tem 200-500 palavras, então o `get_human_typing_time` faz a NPC "digitar" por VÁRIOS minutos reais |
| **calculo_2_pagamentos** | Substitui todo valor `R$ X,XX` em mensagens por uma expressão matemática equivalente onde o N nunca aparece. Ex: `R$ 100,00` vira `R$ ((37 · 66) − 2342),00`. Você TEM que calcular pra saber. Integrais, somatórios, e composições escolhidas via hash determinístico de N |

Combinar mods produz interações interessantes — `long_payment_codes` +
`calculo_2_pagamentos` ativos = "pague R$ ((54·65)−3452),90 pro pix
ANVNBKJ3Q9F2X7..." 🫠

## Considerações de segurança

Mods em `user://mods/` que incluem `main.gd` rodam com **acesso total
às APIs do GDScript**, podem ler/escrever arquivos, chamar
`OS.execute`, etc. O loader emite um warning no console quando carrega
script desse tipo. Mods built-in (em `res://mods/available/`) viajam
junto com o repo, então passam pela revisão de vocês.

_A ironia de um jogo sobre cibersegurança aceitar code injection não me
passou despercebida_ 😅 se vocês quiserem adicionar uma flag tipo
`"trust_user_scripts": false` no `mods_enabled.json` futuramente,
adiciono.

## Limitações conhecidas / TODO

- **Sem hot reload**: ativar/desativar mod exige reiniciar o jogo.
  Adicionar hot reload é complicado por causa de
  scripts já instanciados, scenes ativas, e save state, deixei pra v2 _(talvez)_
- **Apps novos via mod**: o enum `App` em `GameData` é compile-time,
  então mods não podem adicionar apps inteiros sem um `pack.pck` que
  reescreve o enum. Mas dá pra adicionar **conteúdo dentro de apps
  existentes** (mensagens, lojas, news, etc) facilmente
- **Códigos dinâmicos gerados em runtime** (compras feitas pelo player)
  ainda saem com 5/6 chars no `long_payment_codes`, o gerador está
  literal no `bank_director.gd`; cobrir esse caso pediria `pack.pck`
- **Ordem dos mods** é resolvida via `priority` (maior primeiro) +
  dependências declaradas. Funciona, mas é simples, sem topological
  sort robusto pra ciclos. Ciclos atualmente são silenciosamente
  ignorados

## Como testar de forma rápida

1. Pull a branch `mods`
2. Abre no Godot 4.6, importa, F5
3. Menu -> MODS -> ativa **calculo_2_pagamentos** + **long_payment_codes**
4. Salvar -> fechar jogo -> F5 de novo
5. New Game -> no dia 0/1 vc já vai receber uma cobrança absurda

Pra ver todos: ativa todos os 7 e prepara o coração

## Próximos passos

Tenho mais ~25 ideias de mods já listadas (#brincadeira #séria). Os
maiores blockers pros mods mais ambiciosos (skin Windows XP, modo
idoso, captcha de pesca, autenticação govbr 5-etapas) são UI custom e
mecânicas novas, seria interessante um sistema de **hooks adicionais**
no jogo de vocês pra expor pontos de extensão (ex: hook pre/post-open
app, hook na entrega de mensagem, hook em transação concluída) sem
mods precisarem fazer pack.pck.

Se quiserem mergear como tá, ou pedir mudanças, ou só usar como
referência e fazer próprio depois, qualquer caminho é de boa. valeu
demais por terem aberto a branch! 🫡 _(obrigado Lorenzo)_

---

_Os textos foram gerados por AI (mensagens e interações) então se tiver qualquer coisa super estranha é culpa da IA, eu não revisei os textos, só aceitei..._